### PR TITLE
implement breadth-first-search for bossroomgen

### DIFF
--- a/Core/MapGen.cs
+++ b/Core/MapGen.cs
@@ -26,7 +26,7 @@ public class MapGen
             _logger.LogInformation("Rooms: {rooms}", RoomsToString(Rooms));
         } // Generate layout
 
-        GenerateBossRoom(_logger, canvas); // Add bossroom at furthest x value
+        GenerateBossRoom(_logger, canvas); // Add bossroom at furthest position
     }
 
     private void GenerateBossRoom(ILogger _logger, Canvas canvas)

--- a/Core/MapGen.cs
+++ b/Core/MapGen.cs
@@ -2,12 +2,11 @@ using System.Drawing;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using RogueConsole.Enums;
-using RogueConsole.World;
 using RogueConsole.Utils;
+using RogueConsole.World;
 using Sharpie;
 
 namespace RogueConsole.Core;
-
 
 public class MapGen
 {
@@ -30,30 +29,11 @@ public class MapGen
         GenerateBossRoom(_logger, canvas); // Add bossroom at furthest x value
     }
 
-    private void GenerateBossRoom(ILogger _logger, Canvas canvas) // TODO: Improve the select to choose the room furthest i.e most moves from spawn
+    private void GenerateBossRoom(ILogger _logger, Canvas canvas)
     {
-        var biggestDiff = (8, 8);
-        foreach ((int, int) tuple in GetNonEmptyRooms())
-        {
-            if (Math.Abs(tuple.Item1 - 8) > Math.Abs(biggestDiff.Item1 - 8))
-            {
-                biggestDiff = tuple;
-            }
-            ;
-
-            _logger.LogInformation("activerooms: {t}", tuple);
-            _logger.LogInformation("BiggestDiff on X axis: {diff}", biggestDiff);
-        }
-        Rooms[biggestDiff.Item1, biggestDiff.Item2] = TileMap.GetRoom(
-            RoomTypes.Boss,
-            canvas
-        );
-
-        Rooms[biggestDiff.Item1, biggestDiff.Item2].InitMap();
-        _logger.LogInformation(
-            "RoomType of biggestDiff {type}",
-            Rooms[biggestDiff.Item1, biggestDiff.Item2].RoomType
-        );
+        (int x, int y) = BFS.Execute(Rooms, _logger); //Breadth-first-search
+        Rooms[x, y] = TileMap.GetRoom(RoomTypes.Boss, canvas);
+        Rooms[x, y].InitMap();
 
         _logger.LogInformation("Rooms: {rooms}", RoomsToString(Rooms));
     }

--- a/Utils/BFS.cs
+++ b/Utils/BFS.cs
@@ -1,10 +1,7 @@
-using Microsoft.Extensions.Logging;
 using RogueConsole.World;
 
 static class BFS
 {
-    static ILogger logger { get; set; }
-
     private class QuePair
     {
         public int first,
@@ -57,7 +54,7 @@ static class BFS
         q.Enqueue(new QuePair(row, col));
         vis[row, col] = true;
 
-        var lastRoom = (row, col);
+        var lastRoom = (row, col); //TODO: Make sure it selects the room with most hops from spawn
         // Iterate while the queue
         // is not empty
         while (q.Count != 0)
@@ -65,7 +62,6 @@ static class BFS
             QuePair cell = q.Peek();
             int x = cell.first;
             int y = cell.second;
-            logger.LogInformation(" {grid}", grid[x, y]);
             q.Dequeue();
             // Go to the adjacent cells
             for (int i = 0; i < 4; i++)
@@ -84,13 +80,10 @@ static class BFS
     }
 
     // Driver Code
-    public static (int x, int y) Execute(TileMap[,] Rooms, ILogger _logger)
+    public static (int x, int y) Execute(TileMap[,] Rooms)
     {
-        logger = _logger;
-
         // Declare the visited array
         bool[,] vis = new bool[ROW, COL];
         return Search(Rooms, vis, 8, 8);
     }
 }
-

--- a/Utils/BFS.cs
+++ b/Utils/BFS.cs
@@ -1,0 +1,96 @@
+using Microsoft.Extensions.Logging;
+using RogueConsole.World;
+
+static class BFS
+{
+    static ILogger logger { get; set; }
+
+    private class QuePair
+    {
+        public int first,
+            second;
+
+        public QuePair(int first, int second)
+        {
+            this.first = first;
+            this.second = second;
+        }
+    }
+
+    static readonly int ROW = 16;
+    static readonly int COL = 16;
+
+    // Direction vectors
+
+    static int[] dRow = { -1, 0, 1, 0 };
+    static int[] dCol = { 0, 1, 0, -1 };
+
+    // Function to check if a cell
+    // is be visited or not
+    static bool isValid(TileMap[,] Rooms, bool[,] vis, int row, int col)
+    {
+        // If cell lies out of bounds
+        if (row < 0 || col < 0 || row >= ROW || col >= COL)
+            return false;
+
+        if (Rooms[row, col] == null)
+        {
+            return false;
+        }
+
+        // If cell is already visited
+        if (vis[row, col])
+            return false;
+
+        // Otherwise
+        return true;
+    }
+
+    // Function to perform the BFS traversal
+    static (int x, int y) Search(TileMap[,] grid, bool[,] vis, int row, int col)
+    {
+        // Stores indices of the matrix cells
+        Queue<QuePair> q = new Queue<QuePair>();
+
+        // Mark the starting cell as visited
+        // and push it into the queue
+        q.Enqueue(new QuePair(row, col));
+        vis[row, col] = true;
+
+        var lastRoom = (row, col);
+        // Iterate while the queue
+        // is not empty
+        while (q.Count != 0)
+        {
+            QuePair cell = q.Peek();
+            int x = cell.first;
+            int y = cell.second;
+            logger.LogInformation(" {grid}", grid[x, y]);
+            q.Dequeue();
+            // Go to the adjacent cells
+            for (int i = 0; i < 4; i++)
+            {
+                int adjx = x + dRow[i];
+                int adjy = y + dCol[i];
+                if (isValid(grid, vis, adjx, adjy))
+                {
+                    q.Enqueue(new QuePair(adjx, adjy));
+                    vis[adjx, adjy] = true;
+                    lastRoom = (adjx, adjy);
+                }
+            }
+        }
+        return lastRoom;
+    }
+
+    // Driver Code
+    public static (int x, int y) Execute(TileMap[,] Rooms, ILogger _logger)
+    {
+        logger = _logger;
+
+        // Declare the visited array
+        bool[,] vis = new bool[ROW, COL];
+        return Search(Rooms, vis, 8, 8);
+    }
+}
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Boss room placement now uses a breadth-first traversal for selecting the location, replacing the previous heuristic.
* **New Features**
  * Introduced a traversal utility that determines room coordinates during map generation, improving consistency of boss placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->