### PR TITLE
Feat/player take damage

### DIFF
--- a/Core/GameState.cs
+++ b/Core/GameState.cs
@@ -7,10 +7,11 @@ using Vimonia.World;
 using Sharpie;
 using System.Text;
 using Vimonia.World.Maps;
+using Vimonia.Entities;
 
 namespace Vimonia.Core;
 
-public sealed class GameState(Style playerBody, MapGen floor, GameSettings settings, Terminal terminal) {
+public sealed class GameState(Player player, MapGen floor, GameSettings settings, Terminal terminal) {
     public static event EventHandler<GamePhase> CurrentState;
     public static event EventHandler<Point> PlayerInput;
     public static event Action? OnTick; //TODO: Keep or not to keep? That is the question...
@@ -40,9 +41,13 @@ public sealed class GameState(Style playerBody, MapGen floor, GameSettings setti
             position = EnterNewRoom(position);
         }
 
+        if (CurrentRoom.Tiles[position.X, position.Y].Entity != null) {
+            player.TakeDamage(10);
+            Log.Info($"Health: {player.Health}");
+        }
 
         CurrentRoom.RenderToCanvas();
-        Canvas.Glyph(position, GameConstants.Player, playerBody); //Update player position
+        Canvas.Glyph(position, GameConstants.Player, player.Style); //Update player position
         PrevPosition = position;
 
 

--- a/Entities/Entity.cs
+++ b/Entities/Entity.cs
@@ -8,7 +8,6 @@ namespace Vimonia.Entities;
 
 
 public abstract class Entity : IEntity {
-
     public EntityType Type { get; init; }
     public int Health { get; set; }
     public int MaxHealth { get; set; }

--- a/Entities/Player.cs
+++ b/Entities/Player.cs
@@ -16,12 +16,14 @@ public sealed class Player : IEntity {
     public bool IsDead => Health <= 0;
     public Dictionary<string, ISkill> Skills { get; private set; } = [];
     public Point Position { get; set; }
+    public Style Style { get; set; }
 
-    public Player(int health, int maxHealth, List<ISkill>? skills = null) {
+    public Player(int health, int maxHealth, Style style, List<ISkill>? skills = null) {
         Health = health;
         MaxHealth = maxHealth;
         if (skills != null) AddSkills(skills);
         Type = EntityType.Player;
+        Style = style;
 
         GameState.PlayerInput += OnPlayerInput;
         GameState.OnTick += Update;

--- a/Program.cs
+++ b/Program.cs
@@ -2,6 +2,7 @@ using System.Drawing;
 using Vimonia.Core;
 using Vimonia.Enums;
 using Vimonia.Utils;
+using Vimonia.Entities;
 using Sharpie;
 using Sharpie.Backend;
 
@@ -46,11 +47,13 @@ Rng.Init(CanvasWrapper.Instance, 4);
 
 MapGen floor = new(CanvasWrapper.Instance, settings);
 
+Player Player = new(100, 100, new() {
+    Attributes = VideoAttribute.Bold,
+    ColorMixture = terminal.Colors.MixColors(StandardColor.Magenta, StandardColor.Black),
+});
+
 var game = new GameState(
-    new() {
-        Attributes = VideoAttribute.Bold,
-        ColorMixture = terminal.Colors.MixColors(StandardColor.Magenta, StandardColor.Black),
-    },
+        Player,
     floor,
     settings,
     terminal

--- a/World/Tile.cs
+++ b/World/Tile.cs
@@ -17,7 +17,7 @@ public class Tile {
 
     public static Tile Floor() => new() { Glyph = GameConstants.Ground, Walkable = true };
     public static Tile Wall() => new() { Glyph = GameConstants.Wall };
-    public static Tile Goblin(Entity entity) => new() { Text = entity.Body, Entity = entity };
+    public static Tile Goblin(Entity entity) => new() { Text = entity.Body, Entity = entity, Walkable = true };
     public static Tile Player(Player player) => new() { Glyph = GameConstants.Player, Entity = player };
     public static Tile Chest() => new() { Glyph = GameConstants.Item };
     public static Tile Door() => new() { Glyph = GameConstants.Door, Walkable = true };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added entity collision detection: players now take 10 damage when moving into tiles occupied by entities.

* **Improvements**
  * Goblin tiles are now walkable, improving navigation on dungeon floors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->